### PR TITLE
load noblinkothers from settings

### DIFF
--- a/fileio.cpp
+++ b/fileio.cpp
@@ -164,8 +164,8 @@ void Stylist::LoadSettings(const char* Name)
                 }
                 if (_stricmp(SubNode->name(), "noblinkothers") == 0)
                 {
-                    if (_stricmp(SubNode->value(), "false") == 0)
-                        mSettings.NoBlinkOthers = false;
+                    if (_stricmp(SubNode->value(), "true") == 0)
+                        mSettings.NoBlinkOthers = true;
                 }
             }
         }


### PR DESCRIPTION
because `settings_t.NoBlinkOthers` defaults to `false`, setting it to `true` in your settings file won't actually do anything in the original implementation. tested locally.